### PR TITLE
support index placement option, fix generating index definition

### DIFF
--- a/_example/mysql.sql
+++ b/_example/mysql.sql
@@ -3,17 +3,16 @@
 DROP TABLE IF EXISTS `product`;
 
 CREATE TABLE `product` (
-    `id` INTEGER unsigned NOT NULL AUTO_INCREMENT,
+    `id` INTEGER unsigned NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `name` VARCHAR(191) NOT NULL,
     `type` INTEGER unsigned NOT NULL,
     `user_id` INTEGER unsigned NOT NULL,
     `created_at` DATETIME NOT NULL,
     `updated_at` DATETIME NULL,
-    PRIMARY KEY (`id`, `created_at`),
     UNIQUE (`user_id`, `type`),
+    INDEX user_id_created_at (`user_id`, `created_at`),
     FOREIGN KEY (`user_id`) REFERENCES user(`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-CREATE INDEX product_user_id_created_at ON product (`user_id`, `created_at`);
 
 
 DROP TABLE IF EXISTS `user`;

--- a/_example/product.go
+++ b/_example/product.go
@@ -7,9 +7,10 @@ import (
 	"github.com/mackee/go-genddl/index"
 )
 
+// Product is product of user
 //+table: product
 type Product struct {
-	ID        uint32       `db:"id,autoincrement"`
+	ID        uint32       `db:"id,primarykey,autoincrement"`
 	Name      string       `db:"name"`
 	Type      uint32       `db:"type"`
 	UserID    uint32       `db:"user_id"`
@@ -19,7 +20,6 @@ type Product struct {
 
 func (s Product) _schemaIndex(methods index.Methods) []index.Definition {
 	return []index.Definition{
-		methods.PrimaryKey(s.ID, s.CreatedAt),
 		methods.Unique(s.UserID, s.Type),
 		methods.Complex(s.UserID, s.CreatedAt),
 		methods.ForeignKey(s.UserID, User{}.ID, index.ForeignKeyDeleteCascade, index.ForeignKeyUpdateCascade),

--- a/_example/sqlite3.sql
+++ b/_example/sqlite3.sql
@@ -3,15 +3,14 @@
 DROP TABLE IF EXISTS "product";
 
 CREATE TABLE "product" (
-    "id" INTEGER NOT NULL AUTOINCREMENT,
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     "name" TEXT NOT NULL,
     "type" INTEGER NOT NULL,
     "user_id" INTEGER NOT NULL,
     "created_at" DATETIME NOT NULL,
     "updated_at" DATETIME NULL,
-    PRIMARY KEY ("id", "created_at"),
     UNIQUE ("user_id", "type"),
-    FOREIGN KEY ("user_id") REFERENCES user("id") ON DELETE CASCADE ON UPDATE SET CASCADE
+    FOREIGN KEY ("user_id") REFERENCES user("id") ON DELETE CASCADE ON UPDATE CASCADE
 ) ;
 CREATE INDEX product_user_id_created_at ON product ("user_id", "created_at");
 

--- a/_example/user.go
+++ b/_example/user.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 )
 
-//go:generate go run ../cmd/genddl/main.go -outpath=./mysql.sql
+//go:generate go run ../cmd/genddl/main.go -outpath=./mysql.sql -innerindex
 //go:generate go run ../cmd/genddl/main.go -outpath=./sqlite3.sql -driver=sqlite3
 
 //+table: user

--- a/main.go
+++ b/main.go
@@ -28,9 +28,11 @@ func Run(from string) {
 	fromdir := filepath.Dir(from)
 
 	var schemadir, outpath, driverName string
+	var innerIndexDef bool
 	flag.StringVar(&schemadir, "schemadir", fromdir, "schema declaretion directory")
 	flag.StringVar(&outpath, "outpath", "", "schema target path")
 	flag.StringVar(&driverName, "driver", "mysql", "target driver")
+	flag.BoolVar(&innerIndexDef, "innerindex", false, "Placement of index definition. If this specified, the definition was placement inner of `create table`")
 
 	flag.Parse()
 
@@ -40,6 +42,8 @@ func Run(from string) {
 		dialect = MysqlDialect{}
 	case "sqlite3":
 		dialect = Sqlite3Dialect{}
+		// It is not supported by SQLite that placement of index definition inner CREATE TABLE
+		innerIndexDef = false
 	default:
 		log.Fatalf("undefined driver name: %s", driverName)
 	}
@@ -64,7 +68,7 @@ func Run(from string) {
 	for _, tableName := range tableNames {
 		st := tables[tableName]
 		funcs := funcMap[st]
-		tableMap := NewTableMap(tableName, st, funcs, tablesMap, ti)
+		tableMap := NewTableMap(tableName, st, funcs, tablesMap, ti, innerIndexDef)
 		if tableMap != nil {
 			file.WriteString("\n")
 			tableMap.WriteDDL(file, dialect)

--- a/mysql.go
+++ b/mysql.go
@@ -83,19 +83,19 @@ func (m MysqlDialect) ForeignKey(option index.ForeignKeyOption) string {
 	case index.ForeignKeyDeleteSetNull:
 		return "ON DELETE SET NULL"
 	case index.ForeignKeyDeleteSetDefault:
-		return "ON DELETE SET DEFAULT"
+		return "ON DELETE DEFAULT"
 	case index.ForeignKeyDeleteNoAction:
-		return "ON DELETE SET NO ACTION"
+		return "ON DELETE NO ACTION"
 	case index.ForeignKeyUpdateRestrict:
-		return "ON UPDATE SET RISTRICT"
+		return "ON UPDATE RISTRICT"
 	case index.ForeignKeyUpdateCascade:
 		return "ON UPDATE CASCADE"
 	case index.ForeignKeyUpdateSetNull:
-		return "ON UPDATE SET SET NULL"
+		return "ON UPDATE SET NULL"
 	case index.ForeignKeyUpdateSetDefault:
-		return "ON UPDATE SET SET DEFAULT"
+		return "ON UPDATE DEFAULT"
 	case index.ForeignKeyUpdateNoAction:
-		return "ON UPDATE SET NO ACTION"
+		return "ON UPDATE NO ACTION"
 	}
 	return ""
 }

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -64,19 +64,19 @@ func (m Sqlite3Dialect) ForeignKey(option index.ForeignKeyOption) string {
 	case index.ForeignKeyDeleteSetNull:
 		return "ON DELETE SET NULL"
 	case index.ForeignKeyDeleteSetDefault:
-		return "ON DELETE SET DEFAULT"
+		return "ON DELETE DEFAULT"
 	case index.ForeignKeyDeleteNoAction:
-		return "ON DELETE SET NO ACTION"
+		return "ON DELETE NO ACTION"
 	case index.ForeignKeyUpdateRestrict:
-		return "ON UPDATE SET RISTRICT"
+		return "ON UPDATE RISTRICT"
 	case index.ForeignKeyUpdateCascade:
-		return "ON UPDATE SET CASCADE"
+		return "ON UPDATE CASCADE"
 	case index.ForeignKeyUpdateSetNull:
-		return "ON UPDATE SET SET NULL"
+		return "ON UPDATE SET NULL"
 	case index.ForeignKeyUpdateSetDefault:
-		return "ON UPDATE SET SET DEFAULT"
+		return "ON UPDATE DEFAULT"
 	case index.ForeignKeyUpdateNoAction:
-		return "ON UPDATE SET NO ACTION"
+		return "ON UPDATE NO ACTION"
 	}
 	return ""
 }

--- a/tablemap.go
+++ b/tablemap.go
@@ -20,11 +20,11 @@ type TableMap struct {
 	Tables        map[*ast.StructType]string
 }
 
-func NewTableMap(name string, structType *ast.StructType, funcs []*ast.FuncDecl, tables map[*ast.StructType]string, ti *types.Info) *TableMap {
+func NewTableMap(name string, structType *ast.StructType, funcs []*ast.FuncDecl, tables map[*ast.StructType]string, ti *types.Info, innerIndexDef bool) *TableMap {
 	tableMap := new(TableMap)
 	tableMap.Name = name
 
-	tableMap.Indexes = retrieveIndexesByFuncs(funcs, structType)
+	tableMap.Indexes = retrieveIndexesByFuncs(funcs, structType, innerIndexDef)
 	tableMap.Tables = tables
 
 	for _, field := range structType.Fields.List {
@@ -34,7 +34,7 @@ func NewTableMap(name string, structType *ast.StructType, funcs []*ast.FuncDecl,
 	return tableMap
 }
 
-func retrieveIndexesByFuncs(funcs []*ast.FuncDecl, me *ast.StructType) []indexer {
+func retrieveIndexesByFuncs(funcs []*ast.FuncDecl, me *ast.StructType, innerIndexDef bool) []indexer {
 	var f *ast.FuncDecl
 	for _, funcDecl := range funcs {
 		if funcDecl.Name.String() != indexFuncName {
@@ -103,9 +103,10 @@ func retrieveIndexesByFuncs(funcs []*ast.FuncDecl, me *ast.StructType) []indexer
 					}
 				case "Complex":
 					si = indexIdent{
-						Struct: me,
-						Type:   indexComplex,
-						Column: retrieveIndexColumnByExpr(n.Args),
+						Struct:            me,
+						Type:              indexComplex,
+						Column:            retrieveIndexColumnByExpr(n.Args),
+						InnerComplexIndex: innerIndexDef,
 					}
 				case "ForeignKey":
 					options := make([]index.ForeignKeyOption, 0)


### PR DESCRIPTION
* Support `-innerindex` option. It changes the behavior of placement of index definition. This option is for only MySQL dialect.
* Fix any miss of generating index definition. Ex. foreign keys