### PR TITLE
add feature: support BLOB and TEXT

### DIFF
--- a/_example/mysql.sql
+++ b/_example/mysql.sql
@@ -7,6 +7,7 @@ CREATE TABLE `product` (
     `name` VARCHAR(191) NOT NULL,
     `type` INTEGER unsigned NOT NULL,
     `user_id` INTEGER unsigned NOT NULL,
+    `description` TEXT NOT NULL,
     `created_at` DATETIME NOT NULL,
     `updated_at` DATETIME NULL,
     UNIQUE user_id_type (`user_id`, `type`),
@@ -22,6 +23,7 @@ CREATE TABLE `user` (
     `name` VARCHAR(255) NOT NULL UNIQUE,
     `age` BIGINT NULL,
     `message` VARCHAR(191) NULL,
+    `icon_image` BLOB NOT NULL,
     `created_at` DATETIME NOT NULL,
     `updated_at` DATETIME NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/_example/product.go
+++ b/_example/product.go
@@ -10,12 +10,13 @@ import (
 // Product is product of user
 //+table: product
 type Product struct {
-	ID        uint32       `db:"id,primarykey,autoincrement"`
-	Name      string       `db:"name"`
-	Type      uint32       `db:"type"`
-	UserID    uint32       `db:"user_id"`
-	CreatedAt time.Time    `db:"created_at"`
-	UpdatedAt sql.NullTime `db:"updated_at"`
+	ID          uint32       `db:"id,primarykey,autoincrement"`
+	Name        string       `db:"name"`
+	Type        uint32       `db:"type"`
+	UserID      uint32       `db:"user_id"`
+	Description string       `db:"description,text"`
+	CreatedAt   time.Time    `db:"created_at"`
+	UpdatedAt   sql.NullTime `db:"updated_at"`
 }
 
 func (s Product) _schemaIndex(methods index.Methods) []index.Definition {

--- a/_example/sqlite3.sql
+++ b/_example/sqlite3.sql
@@ -7,6 +7,7 @@ CREATE TABLE "product" (
     "name" TEXT NOT NULL,
     "type" INTEGER NOT NULL,
     "user_id" INTEGER NOT NULL,
+    "description" TEXT NOT NULL,
     "created_at" DATETIME NOT NULL,
     "updated_at" DATETIME NULL,
     UNIQUE ("user_id", "type"),
@@ -22,6 +23,7 @@ CREATE TABLE "user" (
     "name" TEXT NOT NULL UNIQUE,
     "age" INTEGER NULL,
     "message" TEXT NULL,
+    "icon_image" BLOB NOT NULL,
     "created_at" DATETIME NOT NULL,
     "updated_at" DATETIME NULL
 ) ;

--- a/_example/user.go
+++ b/_example/user.go
@@ -16,6 +16,7 @@ type User struct {
 	Name      string         `db:"name,unique,size=255"`
 	Age       sql.NullInt64  `db:"age"`
 	Message   sql.NullString `db:"message"`
+	IconImage []byte         `db:"icon_image"`
 	CreatedAt time.Time      `db:"created_at"`
 	UpdatedAt mysql.NullTime `db:"updated_at"`
 }

--- a/mysql.go
+++ b/mysql.go
@@ -34,14 +34,19 @@ func (m MysqlDialect) ToSqlType(col *ColumnMap) string {
 	case "float32":
 		column = "FLOAT"
 	case "string", "sql.NullString":
-		size := MYSQL_DEFAULT_VARCHAR_SIZE
-		if v, ok := col.TagMap["size"]; ok {
-			size = v
+		if _, ok := col.TagMap["text"]; ok {
+			column = "TEXT"
+		} else {
+			size := MYSQL_DEFAULT_VARCHAR_SIZE
+			if v, ok := col.TagMap["size"]; ok {
+				size = v
+			}
+			column = "VARCHAR(" + size + ")"
 		}
-		column = "VARCHAR(" + size + ")"
 	case "time.Time", "sql.NullTime", "mysql.NullTime":
 		column = "DATETIME"
-
+	case "[]byte":
+		column = "BLOB"
 	}
 
 	if _, ok := col.TagMap["null"]; ok || strings.HasPrefix(col.TypeName, "sql.Null") || col.TypeName == "mysql.NullTime" {

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -23,6 +23,8 @@ func (m Sqlite3Dialect) ToSqlType(col *ColumnMap) string {
 		column = "TEXT"
 	case "time.Time", "mysql.NullTime", "sql.NullTime":
 		column = "DATETIME"
+	case "[]byte":
+		column = "BLOB"
 	}
 
 	if _, ok := col.TagMap["null"]; ok || strings.HasPrefix(col.TypeName, "sql.Null") || col.TypeName == "mysql.NullTime" {


### PR DESCRIPTION
## What's this?

* The BLOB and TEXT types are large-length columns
* In the genddl, associate Go types to BLOB and TEXT
  * Go `[]byte` => BLOB
  * Go `string` with `text` option => TEXT