### PR TITLE
fix: table annotation can be contains space for go1.19

### DIFF
--- a/_example/product.go
+++ b/_example/product.go
@@ -11,7 +11,7 @@ import (
 type NullUserID = sql.NullInt32
 
 // Product is product of user
-//+table: product
+// +table: product
 type Product struct {
 	ID             uint32        `db:"id,primarykey,autoincrement"`
 	Name           string        `db:"name"`

--- a/_example/user.go
+++ b/_example/user.go
@@ -10,7 +10,8 @@ import (
 //go:generate go run ../cmd/genddl/main.go -outpath=./mysql.sql -innerindex -uniquename -tablecollate=utf8mb4_general_ci
 //go:generate go run ../cmd/genddl/main.go -outpath=./sqlite3.sql -driver=sqlite3
 
-//+table: user
+// User is a user of the service
+// +table: user
 type User struct {
 	ID        uint32         `db:"id,primarykey,autoincrement"`
 	Name      string         `db:"name,unique,size=255"`

--- a/main.go
+++ b/main.go
@@ -123,8 +123,7 @@ func retrieveTables(schemadir string) (map[string]*ast.StructType, map[*ast.Stru
 			}
 
 			for _, comment := range genDecl.Doc.List {
-				if strings.HasPrefix(comment.Text, "//+table:") {
-					tableName := strings.TrimPrefix(comment.Text, "//+table:")
+				if tableName := trimAnnotation(comment.Text); tableName != comment.Text {
 					tableName = strings.TrimSpace(tableName)
 					spec := genDecl.Specs[0]
 					ts, ok := spec.(*ast.TypeSpec)
@@ -174,4 +173,14 @@ func retrieveTables(schemadir string) (map[string]*ast.StructType, map[*ast.Stru
 	}
 
 	return tables, funcMap, ti, nil
+}
+
+func trimAnnotation(comment string) string {
+	if trimmed := strings.TrimPrefix(comment, "//+table:"); trimmed != comment {
+		return trimmed
+	}
+	if trimmed := strings.TrimPrefix(comment, "// +table:"); trimmed != comment {
+		return trimmed
+	}
+	return comment
 }

--- a/main.go
+++ b/main.go
@@ -176,11 +176,11 @@ func retrieveTables(schemadir string) (map[string]*ast.StructType, map[*ast.Stru
 }
 
 func trimAnnotation(comment string) string {
-	if trimmed := strings.TrimPrefix(comment, "//+table:"); trimmed != comment {
-		return trimmed
-	}
-	if trimmed := strings.TrimPrefix(comment, "// +table:"); trimmed != comment {
-		return trimmed
+	prefixes := []string{"//+table:", "// +table:"}
+	for _, prefix := range prefixes {
+		if trimmed := strings.TrimPrefix(comment, prefix); trimmed != comment {
+			return trimmed
+		}
 	}
 	return comment
 }


### PR DESCRIPTION
## Background

* `go fmt` now includes spaces in comments on go1.19.

## Solution

* Support annotation now that a `// +table: <table name>`.
* Support annotation yet that a `//+table: <table name>` for backward compatibility.