### PR TITLE
Modify go install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Generate RDB DDL by go struct
 ## Install
 
 ```
-$ go install github.com/mackee/go-genddl/cmd/genddl
+$ go install github.com/mackee/go-genddl/cmd/genddl@latest
 ```
 
 ## Example


### PR DESCRIPTION
Thanks for your dedication to this awesome project!

I would like to report that I got the error below when I ran the command in the Install section of README.

```shell
$ go install github.com/mackee/go-genddl/cmd/genddl
go: 'go install' requires a version when current directory is not in a module
	Try 'go install github.com/mackee/go-genddl/cmd/genddl@latest' to install the latest version
```

You have to specify a version explicitly when downloading an executable via `go install`.