### PR TITLE
Support sql.Null[T]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 *~
 vendor/
 go.work
+go.work.sum

--- a/_example/go.mod
+++ b/_example/go.mod
@@ -1,0 +1,6 @@
+module github.com/mackee/go-genddl/_example
+
+go 1.22.4
+
+require github.com/mackee/go-genddl v0.0.0-00010101000000-000000000000
+replace github.com/mackee/go-genddl => ../

--- a/_example/mysql.sql
+++ b/_example/mysql.sql
@@ -19,7 +19,7 @@ CREATE TABLE `product` (
     `name` VARCHAR(191) COLLATE utf8mb4_general_ci NOT NULL,
     `type` INTEGER unsigned NOT NULL,
     `user_id` INTEGER unsigned NOT NULL,
-    `received_user_id` INTEGER NULL,
+    `received_user_id` INTEGER unsigned NULL,
     `description` TEXT COLLATE utf8mb4_general_ci NOT NULL,
     `full_description` MEDIUMTEXT COLLATE utf8mb4_general_ci NOT NULL,
     `size` INTEGER NULL,
@@ -27,6 +27,7 @@ CREATE TABLE `product` (
     `category` TINYINT NOT NULL,
     `created_at` DATETIME(6) NOT NULL,
     `updated_at` DATETIME(6) NULL,
+    `removed_at` DATETIME(6) NULL,
     UNIQUE user_id_type (`user_id`, `type`),
     INDEX user_id_created_at (`user_id`, `created_at`),
     FOREIGN KEY user_id (`user_id`) REFERENCES user(`id`) ON DELETE CASCADE ON UPDATE CASCADE
@@ -52,7 +53,7 @@ CREATE VIEW `user_product`
     LEFT JOIN user AS ru ON p.received_user_id = ru.id;
 
 CREATE VIEW `user_product_structured`
-  (`p_id`, `p_name`, `p_type`, `p_user_id`, `p_received_user_id`, `p_description`, `p_full_description`, `p_size`, `p_status`, `p_category`, `p_created_at`, `p_updated_at`, `u_id`, `u_name`, `u_age`, `u_message`, `u_icon_image`, `u_created_at`, `u_updated_at`, `ru_id`, `ru_name`, `ru_age`, `ru_message`, `ru_icon_image`, `ru_created_at`, `ru_updated_at`) AS
+  (`p_id`, `p_name`, `p_type`, `p_user_id`, `p_received_user_id`, `p_description`, `p_full_description`, `p_size`, `p_status`, `p_category`, `p_created_at`, `p_updated_at`, `p_removed_at`, `u_id`, `u_name`, `u_age`, `u_message`, `u_icon_image`, `u_created_at`, `u_updated_at`, `ru_id`, `ru_name`, `ru_age`, `ru_message`, `ru_icon_image`, `ru_created_at`, `ru_updated_at`) AS
   SELECT p.*, u.*, ru.* FROM product AS p
     INNER JOIN user AS u ON p.user_id = u.id
     LEFT JOIN user AS ru ON p.received_user_id = ru.id;

--- a/_example/product.go
+++ b/_example/product.go
@@ -7,24 +7,22 @@ import (
 	"github.com/mackee/go-genddl/index"
 )
 
-// NullUserID is optional UserID
-type NullUserID = sql.NullInt32
-
 // Product is product of user
 // +table: product
 type Product struct {
-	ID              uint32        `db:"id,primarykey,autoincrement"`
-	Name            string        `db:"name"`
-	Type            uint32        `db:"type"`
-	UserID          uint32        `db:"user_id"`
-	ReceivedUserID  NullUserID    `db:"received_user_id"`
-	Description     string        `db:"description,text"`
-	FullDescription string        `db:"full_description,mediumtext"`
-	Size            sql.NullInt16 `db:"size"`
-	Status          uint8         `db:"status"`
-	Category        int8          `db:"category"`
-	CreatedAt       time.Time     `db:"created_at,precision=6"`
-	UpdatedAt       sql.NullTime  `db:"updated_at,precision=6"`
+	ID              uint32              `db:"id,primarykey,autoincrement"`
+	Name            string              `db:"name"`
+	Type            uint32              `db:"type"`
+	UserID          uint32              `db:"user_id"`
+	ReceivedUserID  sql.Null[UserID]    `db:"received_user_id"`
+	Description     string              `db:"description,text"`
+	FullDescription string              `db:"full_description,mediumtext"`
+	Size            sql.NullInt16       `db:"size"`
+	Status          uint8               `db:"status"`
+	Category        int8                `db:"category"`
+	CreatedAt       time.Time           `db:"created_at,precision=6"`
+	UpdatedAt       sql.NullTime        `db:"updated_at,precision=6"`
+	RemovedAt       sql.Null[time.Time] `db:"removed_at,precision=6"`
 
 	Hidden           string `db:"-"`       // this field is ignored
 	ExportedOtherTag int32  `json:"other"` // no tag field is ignored

--- a/_example/sqlite3.sql
+++ b/_example/sqlite3.sql
@@ -27,6 +27,7 @@ CREATE TABLE "product" (
     "category" INTEGER NOT NULL,
     "created_at" DATETIME NOT NULL,
     "updated_at" DATETIME NULL,
+    "removed_at" DATETIME NULL,
     UNIQUE ("user_id", "type"),
     FOREIGN KEY ("user_id") REFERENCES user("id") ON DELETE CASCADE ON UPDATE CASCADE
 ) ;
@@ -46,13 +47,13 @@ CREATE TABLE "user" (
 ) ;
 
 CREATE VIEW "user_product"
-  ("p_id", "u_name", "ru_name", "p_id", "p_type") AS 
+  ("p_id", "u_name", "ru_name", "p_id", "p_type") AS
   SELECT p.id, u.name, ru.name, p.id, p.type FROM product AS p
     INNER JOIN user AS u ON p.user_id = u.id
     LEFT JOIN user AS ru ON p.received_user_id = ru.id;
 
 CREATE VIEW "user_product_structured"
-  ("p_id", "p_name", "p_type", "p_user_id", "p_received_user_id", "p_description", "p_full_description", "p_size", "p_status", "p_category", "p_created_at", "p_updated_at", "u_id", "u_name", "u_age", "u_message", "u_icon_image", "u_created_at", "u_updated_at", "ru_id", "ru_name", "ru_age", "ru_message", "ru_icon_image", "ru_created_at", "ru_updated_at") AS
+  ("p_id", "p_name", "p_type", "p_user_id", "p_received_user_id", "p_description", "p_full_description", "p_size", "p_status", "p_category", "p_created_at", "p_updated_at", "p_removed_at", "u_id", "u_name", "u_age", "u_message", "u_icon_image", "u_created_at", "u_updated_at", "ru_id", "ru_name", "ru_age", "ru_message", "ru_icon_image", "ru_created_at", "ru_updated_at") AS
   SELECT p.*, u.*, ru.* FROM product AS p
     INNER JOIN user AS u ON p.user_id = u.id
     LEFT JOIN user AS ru ON p.received_user_id = ru.id;

--- a/_example/user.go
+++ b/_example/user.go
@@ -8,10 +8,12 @@ import (
 //go:generate go run ../cmd/genddl/main.go -outpath=./mysql.sql -innerindex -uniquename -foreignkeyname -tablecollate=utf8mb4_general_ci
 //go:generate go run ../cmd/genddl/main.go -outpath=./sqlite3.sql -driver=sqlite3
 
+type UserID uint32
+
 // User is a user of the service
 // +table: user
 type User struct {
-	ID        uint32         `db:"id,primarykey,autoincrement"`
+	ID        UserID         `db:"id,primarykey,autoincrement"`
 	Name      string         `db:"name,unique,size=255"`
 	Age       sql.NullInt64  `db:"age"`
 	Message   sql.NullString `db:"message"`

--- a/dialect.go
+++ b/dialect.go
@@ -3,7 +3,7 @@ package genddl
 import "github.com/mackee/go-genddl/index"
 
 type Dialect interface {
-	ToSqlType(col *ColumnMap) string
+	ToSqlType(col *ColumnMap) (string, error)
 	CreateTableSuffix() string
 	QuoteField(field string) string
 	DriverName() string

--- a/fields.go
+++ b/fields.go
@@ -1,63 +1,144 @@
 package genddl
 
 import (
+	"fmt"
 	"go/types"
 	"strings"
 )
 
 type columnInfo struct {
-	name     string
-	typeName string
-	tagMap   map[string]string
+	name       string
+	typeName   string
+	isNullable bool
+	tagMap     map[string]string
 }
 
-func columnsByFields(t types.Type, ti *types.Info, tagText string, prefix string) []columnInfo {
+var supportedTypes = map[string]struct{}{
+	"time.Time": {},
+}
+
+var nullTypes = map[string]string{
+	"sql.NullBool":    "bool",
+	"sql.NullInt16":   "int16",
+	"sql.NullInt32":   "int32",
+	"sql.NullInt64":   "int64",
+	"sql.NullFloat64": "float64",
+	"sql.NullString":  "string",
+	"sql.NullByte":    "[]byte",
+	"sql.NullTime":    "time.Time",
+	"sql.Null":        "",
+	"mysql.NullTime":  "time.Time",
+}
+
+type columnTypeInfo struct {
+	name       string
+	isNullable bool
+}
+
+func toColumnTypeInfo(t types.Type) (*columnTypeInfo, error) {
+	tname := namedTypeName(t)
+	nt, ok := t.(*types.Named)
+	if !ok {
+		return &columnTypeInfo{
+			name: tname,
+		}, nil
+	}
+
+	if _, ok := supportedTypes[tname]; ok {
+		return &columnTypeInfo{
+			name:       tname,
+			isNullable: false,
+		}, nil
+	}
+	if nt, ok := nullTypes[tname]; ok {
+		tname = nt
+		// empty is generics types
+		if nt == "" {
+			nt, ok := t.(*types.Named)
+			if !ok {
+				return nil, fmt.Errorf("generics types must be named: %s", t.String())
+			}
+			tas := nt.TypeArgs()
+			if tas == nil {
+				return nil, fmt.Errorf("generics types must have type args: %s", t.String())
+			}
+			if tas.Len() != 1 {
+				return nil, fmt.Errorf("generics types must have one type arg: %s", t.String())
+			}
+			tp := tas.At(0)
+			utp, err := toColumnTypeInfo(tp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert to column type info by %s: %w", tp.String(), err)
+			}
+			tname = utp.name
+		}
+		return &columnTypeInfo{
+			name:       tname,
+			isNullable: true,
+		}, nil
+	}
+	ut := nt.Underlying()
+	cti, err := toColumnTypeInfo(ut)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to column type info by %s: %w", ut.String(), err)
+	}
+	return cti, nil
+}
+
+func namedTypeName(t types.Type) string {
+	nt, ok := t.(*types.Named)
+	if !ok {
+		return t.String()
+	}
+	return strings.Join([]string{nt.Obj().Pkg().Name(), nt.Obj().Name()}, ".")
+}
+
+func columnsByFields(t types.Type, ti *types.Info, tagText string, prefix string) ([]columnInfo, error) {
 	tag := parseTag(tagText)
 	if tag == nil || tag["db"] == "" || tag["db"] == "-" {
-		return nil
+		return nil, nil
 	}
 	if _, ok := tag["nested"]; ok {
 		prefix := prefix + tag["db"]
-		return columnsByStruct(t, ti, prefix)
-	}
-	name := tag["db"]
-	var typeName string
-	for {
-		if _, ok := supportedTypes[t.String()]; ok {
-			nt := t.(*types.Named)
-			typeName = strings.Join([]string{nt.Obj().Pkg().Name(), nt.Obj().Name()}, ".")
-			break
+		ret, err := columnsByStruct(t, ti, prefix)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get columns by struct: %w", err)
 		}
-		if ta, ok := t.(*types.Named); ok {
-			t = ta.Underlying()
-			continue
-		} else {
-			typeName = t.String()
-			break
-		}
+		return ret, nil
 	}
-	return []columnInfo{
-		{name: prefix + name, typeName: typeName, tagMap: tag},
+	cti, err := toColumnTypeInfo(t)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to column type info: %w", err)
 	}
+	ci := columnInfo{
+		name:       prefix + tag["db"],
+		tagMap:     tag,
+		typeName:   cti.name,
+		isNullable: cti.isNullable,
+	}
+	return []columnInfo{ci}, nil
 }
 
-func columnsByStruct(t types.Type, ti *types.Info, prefix string) []columnInfo {
+func columnsByStruct(t types.Type, ti *types.Info, prefix string) ([]columnInfo, error) {
 	tn, ok := t.(*types.Named)
 	if !ok {
-		return nil
+		return nil, fmt.Errorf("type must be named: %s", t.String())
 	}
 	ut := tn.Underlying()
 	st, ok := ut.(*types.Struct)
 	if !ok {
-		return nil
+		return nil, fmt.Errorf("underlying type must be struct: %s", ut.String())
 	}
 	columns := make([]columnInfo, 0, st.NumFields())
 	for i := 0; i < st.NumFields(); i++ {
 		field := st.Field(i)
 		tagText := st.Tag(i)
-		cs := columnsByFields(field.Type(), ti, tagText, prefix)
+		cs, err := columnsByFields(field.Type(), ti, tagText, prefix)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get columns by fields: %w", err)
+		}
 		columns = append(columns, cs...)
 	}
 
-	return columns
+	return columns, nil
 }

--- a/main.go
+++ b/main.go
@@ -73,10 +73,15 @@ func Run(from string) {
 	for _, tableName := range tableNames {
 		st := tr.tables[tableName]
 		funcs := tr.funcs[st]
-		tableMap := NewTableMap(tableName, st, funcs, tablesMap, tr.ti, innerIndexDef, uniqueWithName, foreignKeyWithName)
+		tableMap, err := NewTableMap(tableName, st, funcs, tablesMap, tr.ti, innerIndexDef, uniqueWithName, foreignKeyWithName)
+		if err != nil {
+			log.Fatalf("failed to create table map: %s", err)
+		}
 		if tableMap != nil {
 			file.WriteString("\n")
-			tableMap.WriteDDL(file, dialect)
+			if err := tableMap.WriteDDL(file, dialect); err != nil {
+				log.Fatalf("failed to write DDL: %s", err)
+			}
 		}
 	}
 	viewNames := make([]string, 0, len(tr.views))
@@ -86,12 +91,15 @@ func Run(from string) {
 	sort.Strings(viewNames)
 	for _, viewName := range viewNames {
 		v := tr.views[viewName]
-		vm := NewViewMap(newViewMapInput{
+		vm, err := NewViewMap(newViewMapInput{
 			name:  viewName,
 			st:    v,
 			funcs: tr.funcs[v],
 			ti:    tr.ti,
 		})
+		if err != nil {
+			log.Fatalf("[ERROR] failed to create view map: %s", err)
+		}
 		if vm == nil {
 			log.Println("[ERROR] skip view:", viewName)
 			continue

--- a/viewmap_test.go
+++ b/viewmap_test.go
@@ -18,25 +18,27 @@ func TestViewMap(t *testing.T) {
 	funcs := tr.funcs[userProduct]
 
 	bs := &bytes.Buffer{}
-	vm := NewViewMap(newViewMapInput{
+	vm, err := NewViewMap(newViewMapInput{
 		name:  "user_product",
 		st:    userProduct,
 		funcs: funcs,
 		ti:    tr.ti,
 	})
+	if err != nil {
+		t.Errorf("unexpected error on NewViewMap: %s", err)
+		t.FailNow()
+	}
 	if err := vm.WriteDDL(bs, MysqlDialect{}); err != nil {
 		t.Errorf("unexpected error on WriteDDL: %s", err)
 	}
 
-	expect :=
-		"CREATE VIEW `user_product`\n" +
-			"  (`p_id`, `u_name`, `ru_name`, `p_id`, `p_type`) AS\n" +
-			"  SELECT p.id, u.name, ru.name, p.id, p.type FROM product AS p\n" +
-			"    INNER JOIN user AS u ON p.user_id = u.id\n" +
-			"    LEFT JOIN user AS ru ON p.received_user_id = ru.id;\n\n"
+	expect := "CREATE VIEW `user_product`\n" +
+		"  (`p_id`, `u_name`, `ru_name`, `p_id`, `p_type`) AS\n" +
+		"  SELECT p.id, u.name, ru.name, p.id, p.type FROM product AS p\n" +
+		"    INNER JOIN user AS u ON p.user_id = u.id\n" +
+		"    LEFT JOIN user AS ru ON p.received_user_id = ru.id;\n\n"
 
 	if diff := cmp.Diff(expect, bs.String()); diff != "" {
 		t.Errorf("result is mismatch (-want +got):\n%s", diff)
 	}
-
 }


### PR DESCRIPTION
## Overview

This Pull Request adds support for `sql.Null[T]` to the go-genddl library. It also ensures that `sql.Null[T]` works correctly when `T` is a user-defined type by referring to its underlying type. Additionally, some refactoring has been performed for extracting the underlying type.

## Changes

- **Support for `sql.Null[T]`**:
   - Implemented functionality to handle `sql.Null[T]` in DDL generation.
   - Ensured that the correct SQL types are generated for nullable fields.
   - Extended the support for `sql.Null[T]` to work with user-defined types.
   - Used Go's type system to refer to the underlying type of `T` in user-defined types.

## Refactoring

- **Refactoring**:
   - Refactored the code to improve the process of extracting underlying types.
   - Cleaned up related code to enhance readability and maintainability.

## Example

Given the following struct definition:

```go
type MyInt int

type Example struct {
    ID   int
    Name sql.Null[string]
    Age  sql.Null[MyInt]
}
```

The generated DDL will correctly handle `sql.Null[T]` types and user-defined types, resulting in:

```sql
CREATE TABLE example (
    id INTEGER,
    name VARCHAR(191) NULL,
    age INTEGER NULL
);
```