### PR TITLE
fix: imporove generation of foreign key that add the constraint name

### DIFF
--- a/index.go
+++ b/index.go
@@ -82,9 +82,15 @@ func (si indexIdent) Index(dialect Dialect, tables map[*ast.StructType]string) s
 			fmt.Fprintf(bs, "CREATE INDEX %s ON %s (", tableName+"_"+joinAndStripName(si.Name()), tableName)
 		}
 	case indexForeign:
+		tableName := tables[si.Struct]
+		constraintName := joinAndStripName(strings.Join([]string{"fk", tableName, si.Name()}, "_"))
 		if si.OuterForeignKey {
-			tableName := tables[si.Struct]
-			fmt.Fprintf(bs, "ALTER TABLE %s ADD CONSTRAINT %s ", tableName, joinAndStripName(si.Name()))
+			fmt.Fprintf(
+				bs,
+				"ALTER TABLE `%s` ADD CONSTRAINT `%s` ",
+				tableName,
+				constraintName,
+			)
 		} else {
 			bs.WriteString("    ")
 		}


### PR DESCRIPTION
### Description

This Pull Request introduces a change to automatically generate and assign a constraint name when creating foreign keys using the `-outerforeignkey` option in the DDL. 

### Motivation

Some schema management tools compare the current table definition with the desired DDL and generate `ALTER` statements to apply any differences. In these cases, the constraint name is used to verify whether a foreign key definition is already applied. However, when the constraint name is automatically generated by the database, there have been cases where the `ALTER` statement generation fails. By explicitly defining the constraint name in the DDL, this issue can be avoided, ensuring smoother schema updates across different databases.