### PR TITLE
Fix typo R*ESTRICT

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -107,7 +107,7 @@ func (m MysqlDialect) QuoteField(field string) string {
 func (m MysqlDialect) ForeignKey(option index.ForeignKeyOption) string {
 	switch option {
 	case index.ForeignKeyDeleteRestrict:
-		return "ON DELETE RISTRICT"
+		return "ON DELETE RESTRICT"
 	case index.ForeignKeyDeleteCascade:
 		return "ON DELETE CASCADE"
 	case index.ForeignKeyDeleteSetNull:
@@ -117,7 +117,7 @@ func (m MysqlDialect) ForeignKey(option index.ForeignKeyOption) string {
 	case index.ForeignKeyDeleteNoAction:
 		return "ON DELETE NO ACTION"
 	case index.ForeignKeyUpdateRestrict:
-		return "ON UPDATE RISTRICT"
+		return "ON UPDATE RESTRICT"
 	case index.ForeignKeyUpdateCascade:
 		return "ON UPDATE CASCADE"
 	case index.ForeignKeyUpdateSetNull:

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -65,7 +65,7 @@ func (m Sqlite3Dialect) QuoteField(field string) string {
 func (m Sqlite3Dialect) ForeignKey(option index.ForeignKeyOption) string {
 	switch option {
 	case index.ForeignKeyDeleteRestrict:
-		return "ON DELETE RISTRICT"
+		return "ON DELETE RESTRICT"
 	case index.ForeignKeyDeleteCascade:
 		return "ON DELETE CASCADE"
 	case index.ForeignKeyDeleteSetNull:
@@ -75,7 +75,7 @@ func (m Sqlite3Dialect) ForeignKey(option index.ForeignKeyOption) string {
 	case index.ForeignKeyDeleteNoAction:
 		return "ON DELETE NO ACTION"
 	case index.ForeignKeyUpdateRestrict:
-		return "ON UPDATE RISTRICT"
+		return "ON UPDATE RESTRICT"
 	case index.ForeignKeyUpdateCascade:
 		return "ON UPDATE CASCADE"
 	case index.ForeignKeyUpdateSetNull:


### PR DESCRIPTION
Thanks for maintaining the tool!

五月雨式にすみません 🙏🏽

```
Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'RISTRICT
```