### PR TITLE
feat(sqlite3): support a type tag likes other dialects

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -29,7 +29,11 @@ func (m Sqlite3Dialect) ToSqlType(col *ColumnMap) (string, error) {
 			column = "BLOB"
 		}
 	default:
-		return "", fmt.Errorf("unsupported types: %s, column=%s", col.TypeName, col.Name)
+		if v, ok := col.TagMap["type"]; ok {
+			column = v
+		} else {
+			return "", fmt.Errorf("unsupported types: %s, column=%s", col.TypeName, col.Name)
+		}
 	}
 
 	if _, ok := col.TagMap["null"]; ok || col.IsNullable {


### PR DESCRIPTION
This pull request includes a change to the `sqlite3.go` file to enhance the handling of column types in the `ToSqlType` method. The most important change is the addition of a check for a custom type in the `TagMap` before throwing an error for unsupported types.

Enhancements to column type handling:

* [`sqlite3.go`](diffhunk://#diff-2b10fcf999dec2c93bce3364fdeefd688eda6ad78934ac1a2d8b359b57ee7687R32-R37): Added a condition to check if a custom type is specified in the `TagMap` and use it instead of returning an error for unsupported types.